### PR TITLE
Fix camd message len

### DIFF
--- a/camd.c
+++ b/camd.c
@@ -238,7 +238,7 @@ OUT:
 	camd_msg_free(&msg);
 }
 
-struct camd_msg *camd_msg_alloc(enum msg_type msg_type, uint16_t ca_id, uint16_t service_id, uint8_t *data, uint8_t data_len) {
+struct camd_msg *camd_msg_alloc(enum msg_type msg_type, uint16_t ca_id, uint16_t service_id, uint8_t *data, int data_len) {
 	struct camd_msg *c = calloc(1, sizeof(struct camd_msg));
 	c->type       = msg_type;
 	c->ca_id      = ca_id;

--- a/camd.h
+++ b/camd.h
@@ -19,7 +19,7 @@
 
 int connect_client							(int socktype, const char *hostname, const char *service);
 
-struct camd_msg *		camd_msg_alloc		(enum msg_type msg_type, uint16_t ca_id, uint16_t service_id, uint8_t *data, uint8_t data_len);
+struct camd_msg *		camd_msg_alloc		(enum msg_type msg_type, uint16_t ca_id, uint16_t service_id, uint8_t *data, int data_len);
 void					camd_msg_free   	(struct camd_msg **pmsg);
 
 void					camd_set_cw			(struct ts *ts, uint8_t *new_cw, int check_validity);

--- a/data.h
+++ b/data.h
@@ -72,7 +72,8 @@ struct key {
 
 // 4 auth header, 20 header size, 256 max data size, 16 potential padding
 #define CAMD35_HDR_LEN (20)
-#define CAMD35_BUF_LEN (4 + CAMD35_HDR_LEN + 256 + 16)
+#define CAMD35_DATA_SIZE (256)
+#define CAMD35_BUF_LEN (4 + CAMD35_HDR_LEN + CAMD35_DATA_SIZE + 16)
 
 // When this limit is reached invalid_cw flag is set.
 #define ECM_RECV_ERRORS_LIMIT 10
@@ -89,8 +90,8 @@ struct camd_msg {
 	enum msg_type	type;
 	uint16_t		ca_id;
 	uint16_t		service_id;
-	uint8_t			data_len;
-	uint8_t			data[255];
+	int				data_len;
+	uint8_t			data[512];	// enough for now
 	struct ts		*ts;
 };
 


### PR DESCRIPTION
This fixes problems with e.g. TNTSAT, as since some weeks longer ECMs (~380 bytes) are used.