### PR TITLE
Enable reproducible building by dropping build date from version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ MKDEP = $(CROSS)$(CC) -MP -MM -o $*.d $<
 RM = rm -f
 MV = mv -f
 
-BUILD_ID = $(shell date +%F_%R)
 VERSION = $(shell cat RELEASE)
 GIT_VER = $(shell git describe --tags --dirty --always 2>/dev/null)
 ifeq "$(GIT_VER)" ""
@@ -30,8 +29,7 @@ LDFLAGS :=
 CC := cc -I/opt/local/include
 endif
 
-DEFS = -DBUILD_ID=\"$(BUILD_ID)\" \
- -DVERSION=\"$(VERSION)\" -DGIT_VER=\"$(GIT_VER)\"
+DEFS = -DVERSION=\"$(VERSION)\" -DGIT_VER=\"$(GIT_VER)\"
 DEFS += -D_FILE_OFFSET_BITS=64
 
 PREFIX ?= /usr/local

--- a/tsdecrypt.c
+++ b/tsdecrypt.c
@@ -38,7 +38,7 @@
 #define FIRST_REPORT_SEC 3
 
 #define PROGRAM_NAME "tsdecrypt"
-static const char *program_id = PROGRAM_NAME " v" VERSION " (" GIT_VER ", build " BUILD_ID " " DLIB ")";
+static const char *program_id = PROGRAM_NAME " v" VERSION " (" GIT_VER ", " DLIB ")";
 
 int keep_running = 1;
 static FILE *log_file = NULL;


### PR DESCRIPTION
Not embedding the build date/time into the binary allows building tsdecrypt reproducibly.