### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/util.c
+++ b/util.c
@@ -159,14 +159,14 @@ int decode_hex_string(char *hex, uint8_t *bin, int asc_len) {
 	return asc_len / 2;
 }
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
 
 int64_t get_time(void) {
 	struct timespec ts;
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 // OS X does not have clock_gettime, use clock_get_time
 	clock_serv_t cclock;
 	mach_timespec_t mts;


### PR DESCRIPTION
Hurd also uses Mach, causing it to hit this ifdef, when it is only intended for OSX.

https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```